### PR TITLE
Upgrade to libdns v1.1

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -6,22 +6,62 @@ import (
 	"os"
 
 	"github.com/libdns/katapult"
+	"github.com/libdns/libdns"
 )
 
 var (
 	envToken = os.Getenv("LIBDNS_KATAPULT_API_TOKEN")
 	envZone  = os.Getenv("LIBDNS_KATAPULT_ZONE")
 )
-
 func main() {
 	p := katapult.Provider{APIToken: envToken}
 
-	ret, err := p.GetRecords(context.TODO(), envZone)
+	records, err := p.SetRecords(context.TODO(), envZone, []libdns.Record{
+		libdns.TXT{
+			Name: "testrecord",
+			TTL:  0,
+			Text: "hello world",
+		},
+	})
 
 	if err != nil {
 		fmt.Println("Error:", err)
 		return
 	}
 
-	fmt.Println("Result:", ret)
+	recordsToDelete := []libdns.Record{}
+
+	for _, r := range records {
+		fmt.Println("Set:", r)
+
+		// Call .RR() on record before deleting it as it drops provider specific metadata
+		recordsToDelete = append(recordsToDelete, r.RR())
+	}
+
+	// Update the record with new text
+	updatedRecords, err := p.SetRecords(context.TODO(), envZone, []libdns.Record{
+		libdns.TXT{
+			Name: "testrecord",
+			TTL:  0,
+			Text: "updated text",
+		},
+	})
+
+	if err != nil {
+		fmt.Println("Error:", err)
+		return
+	}
+
+	for _, r := range updatedRecords {
+		fmt.Println("Updated:", r)
+	}
+
+	deletedRecords, err := p.DeleteRecords(context.TODO(), envZone, recordsToDelete)
+
+	if err != nil {
+		fmt.Println("Error:", err)
+		return
+	}
+
+	fmt.Println("Deleted:", deletedRecords)
 }

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/libdns/katapult
 
 go 1.18
 
-require github.com/libdns/libdns v0.2.2
+require github.com/libdns/libdns v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/libdns/libdns v0.2.2 h1:O6ws7bAfRPaBsgAYt8MDe2HcNBGC29hkZ9MX2eUSX3s=
-github.com/libdns/libdns v0.2.2/go.mod h1:4Bj9+5CQiNMVGf87wjX4CY3HQJypUHRuLvlsfsZqLWQ=
+github.com/libdns/libdns v1.1.1 h1:wPrHrXILoSHKWJKGd0EiAVmiJbFShguILTg9leS/P/U=
+github.com/libdns/libdns v1.1.1/go.mod h1:4Bj9+5CQiNMVGf87wjX4CY3HQJypUHRuLvlsfsZqLWQ=

--- a/models.go
+++ b/models.go
@@ -3,6 +3,9 @@ package katapult
 import (
 	"errors"
 	"fmt"
+	"net/netip"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/libdns/libdns"
@@ -36,41 +39,210 @@ type DeletionAPIResponse struct {
 	Deleted bool `json:"deleted"`
 }
 
+// recordMetadata stores Katapult-specific metadata associated with DNS records.
+type recordMetadata struct {
+	ID string
+}
+
+// genericRecord is used for record types that do not have a dedicated libdns struct.
+type genericRecord struct {
+	record   libdns.RR
+	metadata recordMetadata
+}
+
+// RR satisfies the libdns.Record interface.
+func (r genericRecord) RR() libdns.RR {
+	return r.record
+}
+
 // ToLibDNSRecord converts a DNSRecord to a libdns.Record.
 func (p *Provider) ToLibDNSRecord(r DNSRecord) libdns.Record {
-	return libdns.Record{
-		ID:       r.ID,
-		Type:     r.Type,
-		Name:     r.Name,
-		Value:    r.Content,
-		TTL:      time.Duration(r.TTL) * time.Second,
-		Priority: r.Priority,
+	ttl := time.Duration(r.TTL) * time.Second
+	meta := recordMetadata{ID: r.ID}
+
+	switch r.Type {
+	case "A", "AAAA":
+		if ip, err := netip.ParseAddr(r.Content); err == nil {
+			return libdns.Address{
+				Name:         r.Name,
+				TTL:          ttl,
+				IP:           ip,
+				ProviderData: meta,
+			}
+		}
+	case "CNAME":
+		return libdns.CNAME{
+			Name:         r.Name,
+			TTL:          ttl,
+			Target:       r.Content,
+			ProviderData: meta,
+		}
+	case "MX":
+		return libdns.MX{
+			Name:         r.Name,
+			TTL:          ttl,
+			Preference:   uint16(r.Priority),
+			Target:       r.Content,
+			ProviderData: meta,
+		}
+	case "NS":
+		return libdns.NS{
+			Name:         r.Name,
+			TTL:          ttl,
+			Target:       r.Content,
+			ProviderData: meta,
+		}
+	case "TXT":
+		return libdns.TXT{
+			Name:         r.Name,
+			TTL:          ttl,
+			Text:         r.Content,
+			ProviderData: meta,
+		}
+	}
+
+	return genericRecord{
+		record: libdns.RR{
+			Name: r.Name,
+			TTL:  ttl,
+			Type: r.Type,
+			Data: r.Content,
+		},
+		metadata: meta,
 	}
 }
 
 // FromLibDNSRecord converts a libdns.Record to an API request body.
-func (p *Provider) FromLibDNSRecord(record libdns.Record) (interface{}, error) {
-	content := map[string]interface{}{}
-
-	switch record.Type {
-	case "A", "AAAA", "IPS":
-		content["ip_address"] = record.Value
-	case "ALIAS", "CNAME", "MX", "NS", "PTR":
-		content["hostname"] = record.Value
-	case "TXT":
-		content["content"] = record.Value
-	default:
-		return nil, fmt.Errorf("%w: %s", errUnsupportedRecordType, record.Type)
+func (p *Provider) FromLibDNSRecord(record libdns.Record) (map[string]interface{}, error) {
+	rr := record.RR()
+	properties := map[string]interface{}{
+		"type": rr.Type,
+		"name": rr.Name,
 	}
 
-	return map[string]interface{}{
-		"type": record.Type,
-		"name": record.Name,
-		"ttl":  ensureValidTTL(record.TTL),
-		"content": map[string]interface{}{
-			record.Type: content,
-		},
-	}, nil
+	if ttl := ensureValidTTL(rr.TTL); ttl != nil {
+		properties["ttl"] = ttl
+	}
+
+	content := map[string]interface{}{}
+
+	switch r := record.(type) {
+	case libdns.Address:
+		content["ip_address"] = addrValue(r.IP, rr.Data)
+	case *libdns.Address:
+		if r != nil {
+			content["ip_address"] = addrValue(r.IP, rr.Data)
+		}
+	case libdns.CNAME:
+		content["hostname"] = fallbackString(r.Target, rr.Data)
+	case *libdns.CNAME:
+		if r != nil {
+			content["hostname"] = fallbackString(r.Target, rr.Data)
+		}
+	case libdns.NS:
+		content["hostname"] = fallbackString(r.Target, rr.Data)
+	case *libdns.NS:
+		if r != nil {
+			content["hostname"] = fallbackString(r.Target, rr.Data)
+		}
+	case libdns.MX:
+		content["hostname"] = fallbackString(r.Target, rr.Data)
+		if r.Preference > 0 {
+			properties["priority"] = int(r.Preference)
+		}
+	case *libdns.MX:
+		if r != nil {
+			content["hostname"] = fallbackString(r.Target, rr.Data)
+			if r.Preference > 0 {
+				properties["priority"] = int(r.Preference)
+			}
+		}
+	case libdns.TXT:
+		content["content"] = fallbackString(r.Text, rr.Data)
+	case *libdns.TXT:
+		if r != nil {
+			content["content"] = fallbackString(r.Text, rr.Data)
+		}
+	default:
+		fallbackContent, extra := fallbackContentFromRR(rr)
+		if fallbackContent == nil {
+			return nil, fmt.Errorf("%w: %s", errUnsupportedRecordType, rr.Type)
+		}
+		for k, v := range extra {
+			properties[k] = v
+		}
+		content = fallbackContent
+	}
+
+	if len(content) == 0 {
+		fallbackContent, extra := fallbackContentFromRR(rr)
+		if fallbackContent == nil {
+			return nil, fmt.Errorf("%w: %s", errUnsupportedRecordType, rr.Type)
+		}
+		for k, v := range extra {
+			properties[k] = v
+		}
+		content = fallbackContent
+	}
+
+	properties["content"] = map[string]interface{}{
+		rr.Type: content,
+	}
+
+	return properties, nil
+}
+
+func fallbackContentFromRR(rr libdns.RR) (map[string]interface{}, map[string]interface{}) {
+	content := map[string]interface{}{}
+	extra := map[string]interface{}{}
+
+	switch rr.Type {
+	case "A", "AAAA", "IPS":
+		content["ip_address"] = rr.Data
+	case "ALIAS", "CNAME", "NS", "PTR":
+		content["hostname"] = rr.Data
+	case "MX":
+		host, priority := parseMXData(rr.Data)
+		content["hostname"] = host
+		if priority != nil && *priority > 0 {
+			extra["priority"] = *priority
+		}
+	case "TXT":
+		content["content"] = rr.Data
+	default:
+		return nil, nil
+	}
+
+	return content, extra
+}
+
+func parseMXData(data string) (string, *int) {
+	fields := strings.Fields(data)
+	if len(fields) == 0 {
+		return data, nil
+	}
+	if len(fields) == 1 {
+		return fields[0], nil
+	}
+	priority, err := strconv.Atoi(fields[0])
+	if err != nil {
+		return data, nil
+	}
+	return fields[1], &priority
+}
+
+func fallbackString(primary, fallback string) string {
+	if strings.TrimSpace(primary) != "" {
+		return primary
+	}
+	return fallback
+}
+
+func addrValue(ip netip.Addr, fallback string) string {
+	if ip.IsValid() {
+		return ip.String()
+	}
+	return fallback
 }
 
 func ensureValidTTL(rawTTL time.Duration) *int {
@@ -82,4 +254,161 @@ func ensureValidTTL(rawTTL time.Duration) *int {
 		return &minTTL
 	}
 	return &ttl
+}
+
+func recordID(record libdns.Record) string {
+	switch r := record.(type) {
+	case libdns.Address:
+		return metadataID(r.ProviderData)
+	case *libdns.Address:
+		if r != nil {
+			return metadataID(r.ProviderData)
+		}
+	case libdns.CNAME:
+		return metadataID(r.ProviderData)
+	case *libdns.CNAME:
+		if r != nil {
+			return metadataID(r.ProviderData)
+		}
+	case libdns.MX:
+		return metadataID(r.ProviderData)
+	case *libdns.MX:
+		if r != nil {
+			return metadataID(r.ProviderData)
+		}
+	case libdns.NS:
+		return metadataID(r.ProviderData)
+	case *libdns.NS:
+		if r != nil {
+			return metadataID(r.ProviderData)
+		}
+	case libdns.TXT:
+		return metadataID(r.ProviderData)
+	case *libdns.TXT:
+		if r != nil {
+			return metadataID(r.ProviderData)
+		}
+	case genericRecord:
+		return r.metadata.ID
+	case *genericRecord:
+		if r != nil {
+			return r.metadata.ID
+		}
+	case libdns.RR:
+		return ""
+	case *libdns.RR:
+		return ""
+	}
+
+	return metadataID(nil)
+}
+
+func setRecordID(record libdns.Record, id string) libdns.Record {
+	if id == "" {
+		return record
+	}
+	meta := recordMetadata{ID: id}
+
+	switch r := record.(type) {
+	case libdns.Address:
+		r.ProviderData = meta
+		return r
+	case *libdns.Address:
+		if r == nil {
+			return r
+		}
+		copy := *r
+		copy.ProviderData = meta
+		return copy
+	case libdns.CNAME:
+		r.ProviderData = meta
+		return r
+	case *libdns.CNAME:
+		if r == nil {
+			return r
+		}
+		copy := *r
+		copy.ProviderData = meta
+		return copy
+	case libdns.MX:
+		r.ProviderData = meta
+		return r
+	case *libdns.MX:
+		if r == nil {
+			return r
+		}
+		copy := *r
+		copy.ProviderData = meta
+		return copy
+	case libdns.NS:
+		r.ProviderData = meta
+		return r
+	case *libdns.NS:
+		if r == nil {
+			return r
+		}
+		copy := *r
+		copy.ProviderData = meta
+		return copy
+	case libdns.TXT:
+		r.ProviderData = meta
+		return r
+	case *libdns.TXT:
+		if r == nil {
+			return r
+		}
+		copy := *r
+		copy.ProviderData = meta
+		return copy
+	case genericRecord:
+		r.metadata = meta
+		return r
+	case *genericRecord:
+		if r == nil {
+			return r
+		}
+		copy := *r
+		copy.metadata = meta
+		return copy
+	case libdns.RR:
+		return genericRecord{
+			record:   r,
+			metadata: meta,
+		}
+	case *libdns.RR:
+		if r == nil {
+			return r
+		}
+		return genericRecord{
+			record:   *r,
+			metadata: meta,
+		}
+	default:
+		return genericRecord{
+			record:   record.RR(),
+			metadata: meta,
+		}
+	}
+}
+
+func metadataID(data any) string {
+	switch v := data.(type) {
+	case recordMetadata:
+		return v.ID
+	case *recordMetadata:
+		if v != nil {
+			return v.ID
+		}
+	case string:
+		return v
+	case map[string]string:
+		return v["id"]
+	case map[string]interface{}:
+		if id, ok := v["id"]; ok {
+			if s, ok := id.(string); ok {
+				return s
+			}
+		}
+	}
+	return ""
 }

--- a/provider.go
+++ b/provider.go
@@ -105,12 +105,30 @@ func (p *Provider) SetRecords(ctx context.Context, zone string, records []libdns
 func (p *Provider) DeleteRecords(ctx context.Context, zone string, records []libdns.Record) ([]libdns.Record, error) {
 	var deletedRecords []libdns.Record
 
+	// Fetch existing records to get their IDs
+	existingRecords, err := p.GetRecords(ctx, zone)
+	if err != nil {
+		return deletedRecords, err
+	}
+
 	for _, record := range records {
-		recID := recordID(record)
+		rr := record.RR()
+
+		// Find matching record from existing records
+		var recID string
+		for _, existing := range existingRecords {
+			existingRR := existing.RR()
+			if existingRR.Type == rr.Type && existingRR.Name == rr.Name && existingRR.Data == rr.Data {
+				recID = recordID(existing)
+				break
+			}
+		}
+
 		if recID == "" {
-			rr := record.RR()
 			return deletedRecords, fmt.Errorf("%w: type %s, name %s", errMissingRecordID, rr.Type, rr.Name)
 		}
+
+		fmt.Println("Deleting record ID:", recID)
 
 		url := "/dns_records/" + recID
 

--- a/provider.go
+++ b/provider.go
@@ -128,8 +128,6 @@ func (p *Provider) DeleteRecords(ctx context.Context, zone string, records []lib
 			return deletedRecords, fmt.Errorf("%w: type %s, name %s", errMissingRecordID, rr.Type, rr.Name)
 		}
 
-		fmt.Println("Deleting record ID:", recID)
-
 		url := "/dns_records/" + recID
 
 		var apiResponse DeletionAPIResponse

--- a/provider.go
+++ b/provider.go
@@ -14,7 +14,10 @@ type Provider struct {
 	APIToken string `json:"api_token,omitempty"`
 }
 
-var errFailedToDeleteRecord = errors.New("failed to delete record")
+var (
+	errFailedToDeleteRecord = errors.New("failed to delete record")
+	errMissingRecordID      = errors.New("record id is required")
+)
 
 // GetRecords lists all the records in the zone.
 func (p *Provider) GetRecords(ctx context.Context, zone string) ([]libdns.Record, error) {
@@ -69,11 +72,11 @@ func (p *Provider) SetRecords(ctx context.Context, zone string, records []libdns
 		var url string
 		var method string
 
-		if record.ID == "" {
+		if id := recordID(record); id == "" {
 			url = "/dns_zones/_/records"
 			method = http.MethodPost
 		} else {
-			url = "/dns_records/" + record.ID
+			url = "/dns_records/" + id
 			method = http.MethodPatch
 		}
 
@@ -103,7 +106,13 @@ func (p *Provider) DeleteRecords(ctx context.Context, zone string, records []lib
 	var deletedRecords []libdns.Record
 
 	for _, record := range records {
-		url := "/dns_records/" + record.ID
+		recID := recordID(record)
+		if recID == "" {
+			rr := record.RR()
+			return deletedRecords, fmt.Errorf("%w: type %s, name %s", errMissingRecordID, rr.Type, rr.Name)
+		}
+
+		url := "/dns_records/" + recID
 
 		var apiResponse DeletionAPIResponse
 		if err := p.DoRequest(ctx, http.MethodDelete, url, nil, &apiResponse); err != nil {
@@ -113,7 +122,7 @@ func (p *Provider) DeleteRecords(ctx context.Context, zone string, records []lib
 		if apiResponse.Deleted {
 			deletedRecords = append(deletedRecords, record)
 		} else {
-			return deletedRecords, fmt.Errorf("%w: %s", errFailedToDeleteRecord, record.ID)
+			return deletedRecords, fmt.Errorf("%w: %s", errFailedToDeleteRecord, recID)
 		}
 	}
 

--- a/provider_test.go
+++ b/provider_test.go
@@ -127,7 +127,27 @@ func TestGetRecords(t *testing.T) {
 
 			records, err := provider.GetRecords(context.Background(), data.zone)
 			assertErrorIs(t, err, data.expectedErr)
-			assertRecordListsEqual(t, records, data.expectedRecords)
+
+			// For successful cases, verify our provisioned records are in the results
+			if data.expectedErr == nil && len(data.expectedRecords) > 0 {
+				// Find the provisioned record in the returned records
+				found := false
+				for _, record := range records {
+					rr := record.RR()
+					expectedRR := data.expectedRecords[0].RR()
+					if rr.Type == expectedRR.Type && rr.Name == expectedRR.Name && rr.Data == expectedRR.Data {
+						found = true
+						// Verify the record matches
+						assertRecordListsEqual(t, []libdns.Record{record}, data.expectedRecords)
+						break
+					}
+				}
+				if !found {
+					t.Fatalf("expected to find provisioned record %v in results, but it was not present", data.expectedRecords[0].RR())
+				}
+			} else {
+				assertRecordListsEqual(t, records, data.expectedRecords)
+			}
 		})
 	}
 }

--- a/provider_test.go
+++ b/provider_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/netip"
 	"os"
 	"testing"
 	"time"
@@ -25,10 +26,10 @@ func provisionRecords(t *testing.T, provider *Provider, zone string, recordsToPr
 	}
 
 	if len(provisionedRecords) > 0 {
-		// Replace placeholder IDs of any existing records to test with a real ID from the provision
+		actualID := recordID(provisionedRecords[0])
 		for i, record := range recordsToTest {
-			if record.ID != "" {
-				recordsToTest[i].ID = provisionedRecords[0].ID
+			if recordID(record) != "" {
+				recordsToTest[i] = setRecordID(record, actualID)
 			}
 		}
 	}
@@ -67,23 +68,23 @@ func assertRecordListsEqual(t *testing.T, actual, expected []libdns.Record) {
 	}
 
 	for i := range expected {
-		if actual[i].ID == "" {
-			t.Fatalf("expected record ID to be present, but got nil")
+		actualRR := actual[i].RR()
+		expectedRR := expected[i].RR()
+
+		if recordID(actual[i]) == "" {
+			t.Fatalf("expected record ID to be present, but got empty for %s %s", actualRR.Type, actualRR.Name)
 		}
-		if actual[i].Type != expected[i].Type {
-			t.Fatalf("expected record Type %s, but got %s", expected[i].Type, actual[i].Type)
+		if actualRR.Type != expectedRR.Type {
+			t.Fatalf("expected record Type %s, but got %s", expectedRR.Type, actualRR.Type)
 		}
-		if actual[i].Name != expected[i].Name {
-			t.Fatalf("expected record Name %s, but got %s", expected[i].Name, actual[i].Name)
+		if actualRR.Name != expectedRR.Name {
+			t.Fatalf("expected record Name %s, but got %s", expectedRR.Name, actualRR.Name)
 		}
-		if actual[i].Value != expected[i].Value {
-			t.Fatalf("expected record Value %s, but got %s", expected[i].Value, actual[i].Value)
+		if actualRR.Data != expectedRR.Data {
+			t.Fatalf("expected record Data %s, but got %s", expectedRR.Data, actualRR.Data)
 		}
-		if actual[i].TTL != expected[i].TTL {
-			t.Fatalf("expected record TTL %v, but got %v", expected[i].TTL, actual[i].TTL)
-		}
-		if actual[i].Priority != expected[i].Priority {
-			t.Fatalf("expected record Priority %d, but got %d", expected[i].Priority, actual[i].Priority)
+		if actualRR.TTL != expectedRR.TTL {
+			t.Fatalf("expected record TTL %v, but got %v", expectedRR.TTL, actualRR.TTL)
 		}
 	}
 }
@@ -98,20 +99,17 @@ func TestGetRecords(t *testing.T) {
 		"Success": {
 			zone: envZone + ".",
 			recordsToProvision: []libdns.Record{
-				{
-					Type:  "A",
-					Name:  "example.com",
-					Value: "127.0.0.1",
-					TTL:   time.Duration(300) * time.Second,
+				libdns.Address{
+					Name: "example.com",
+					TTL:  300 * time.Second,
+					IP:   netip.MustParseAddr("127.0.0.1"),
 				},
 			},
 			expectedRecords: []libdns.Record{
-				{
-					Type:     "A",
-					Name:     "example.com",
-					Value:    "127.0.0.1",
-					TTL:      time.Duration(300) * time.Second,
-					Priority: 0,
+				libdns.Address{
+					Name: "example.com",
+					TTL:  300 * time.Second,
+					IP:   netip.MustParseAddr("127.0.0.1"),
 				},
 			},
 		},
@@ -144,29 +142,25 @@ func TestAppendRecords(t *testing.T) {
 		"Success": {
 			zone: envZone + ".",
 			recordsToAdd: []libdns.Record{
-				{
-					Type:  "CNAME",
-					Name:  "test",
-					Value: "test",
+				libdns.CNAME{
+					Name:   "test",
+					Target: "test",
 				},
 			},
 			expectedRecords: []libdns.Record{
-				{
-					Type:  "CNAME",
-					Name:  "test",
-					Value: "test." + envZone,
-					TTL:   time.Duration(0) * time.Second,
+				libdns.CNAME{
+					Name:   "test",
+					Target: "test." + envZone,
 				},
 			},
 		},
 		"API Error": {
 			zone: "_",
 			recordsToAdd: []libdns.Record{
-				{
-					Type:  "CNAME",
-					Name:  "test",
-					Value: "test",
-					TTL:   time.Duration(300) * time.Second,
+				libdns.CNAME{
+					Name:   "test",
+					Target: "test",
+					TTL:    300 * time.Second,
 				},
 			},
 			expectedErr: errUnexpectedStatusCode,
@@ -195,51 +189,44 @@ func TestSetRecords(t *testing.T) {
 		"Success": {
 			zone: envZone + ".",
 			recordsToProvision: []libdns.Record{
-				{
-					Type:  "A",
-					Name:  "testrecord.com",
-					Value: "0.0.0.0",
-					TTL:   time.Duration(300) * time.Second,
+				libdns.Address{
+					Name: "testrecord.com",
+					TTL:  300 * time.Second,
+					IP:   netip.MustParseAddr("0.0.0.0"),
 				},
 			},
 			recordsToSet: []libdns.Record{
-				{
-					ID:    "existingrecord", // here we test changing the type and value of the existing record
-					Type:  "TXT",
-					Name:  "testrecord.com",
-					Value: "hello",
-					TTL:   time.Duration(300) * time.Second,
-				},
-				{
-					Type:  "A",
-					Name:  "newrecord.com",
-					Value: "0.0.0.0",
-					TTL:   time.Duration(300) * time.Second,
+				setRecordID(libdns.TXT{
+					Name: "testrecord.com",
+					TTL:  300 * time.Second,
+					Text: "hello",
+				}, "existingrecord"),
+				libdns.Address{
+					Name: "newrecord.com",
+					TTL:  300 * time.Second,
+					IP:   netip.MustParseAddr("0.0.0.0"),
 				},
 			},
 			expectedRecords: []libdns.Record{
-				{
-					Type:  "TXT",
-					Name:  "testrecord.com",
-					Value: "hello",
-					TTL:   time.Duration(300) * time.Second,
+				libdns.TXT{
+					Name: "testrecord.com",
+					TTL:  300 * time.Second,
+					Text: "hello",
 				},
-				{
-					Type:  "A",
-					Name:  "newrecord.com",
-					Value: "0.0.0.0",
-					TTL:   time.Duration(300) * time.Second,
+				libdns.Address{
+					Name: "newrecord.com",
+					TTL:  300 * time.Second,
+					IP:   netip.MustParseAddr("0.0.0.0"),
 				},
 			},
 		},
 		"API Error": {
 			zone: "_",
 			recordsToSet: []libdns.Record{
-				{
-					Type:  "A",
-					Name:  "newrecord.com",
-					Value: "0.0.0.0",
-					TTL:   time.Duration(300) * time.Second,
+				libdns.Address{
+					Name: "newrecord.com",
+					TTL:  300 * time.Second,
+					IP:   netip.MustParseAddr("0.0.0.0"),
 				},
 			},
 			expectedErr: errUnexpectedStatusCode,
@@ -270,35 +257,31 @@ func TestDeleteRecords(t *testing.T) {
 		"Success": {
 			zone: envZone + ".",
 			recordsToProvision: []libdns.Record{
-				{
-					Type:  "A",
-					Name:  "testrecord.com",
-					Value: "0.0.0.0",
-					TTL:   time.Duration(300) * time.Second,
+				libdns.Address{
+					Name: "testrecord.com",
+					TTL:  300 * time.Second,
+					IP:   netip.MustParseAddr("0.0.0.0"),
 				},
 			},
 			recordsToDelete: []libdns.Record{
-				{
-					ID:   "existingrecord",
-					Type: "A",
+				setRecordID(libdns.Address{
 					Name: "testrecord.com",
-				},
+					IP:   netip.MustParseAddr("0.0.0.0"),
+				}, "existingrecord"),
 			},
 			expectedRecords: []libdns.Record{
-				{
-					Type: "A",
+				libdns.Address{
 					Name: "testrecord.com",
+					IP:   netip.MustParseAddr("0.0.0.0"),
 				},
 			},
 		},
 		"API Error": {
 			zone: "_",
 			recordsToDelete: []libdns.Record{
-				{
-					ID:   "existingrecord",
-					Type: "A",
+				setRecordID(libdns.Address{
 					Name: "example.com",
-				},
+				}, "existingrecord"),
 			},
 			expectedErr: errUnexpectedStatusCode,
 		},


### PR DESCRIPTION
libdns v1 created some breaking changes so trying to use `github.com/caddy-dns/katapult` with the latest version of Caddy caused it to fail during build.

This PR upgrades libdns to v1.1 and updates it with the new record names.

The tests pass but I've been unable to test it with a build of Caddy as the `caddy-dns/katapult` repo would also need updating once this has been merged.